### PR TITLE
Added A workaround to support enum database data type

### DIFF
--- a/src/AcaciaServiceProvider.php
+++ b/src/AcaciaServiceProvider.php
@@ -15,6 +15,7 @@ class AcaciaServiceProvider extends ModulesServiceProvider
     {
         $this->registerNamespaces();
         $this->registerModules();
+        \DB::getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
     }
 
     /**

--- a/src/Commands/stubs/model.permissions.stub
+++ b/src/Commands/stubs/model.permissions.stub
@@ -49,6 +49,6 @@ class $CLASS$ extends \Spatie\Permission\Models\Permission
     $MORPH_TO$
     public function toSearchableArray(): array
     {
-        return $this->only($this->getFillable());
+        return collect($this->only($this->getFillable()))->merge(['id' => $this->getKey()])->toArray();
     }
 }

--- a/src/Commands/stubs/model.roles.stub
+++ b/src/Commands/stubs/model.roles.stub
@@ -34,6 +34,6 @@ class $CLASS$ extends \Spatie\Permission\Models\Role
     $MORPH_TO$
     public function toSearchableArray(): array
     {
-        return $this->only($this->getFillable());
+        return collect($this->only($this->getFillable()))->merge(['id' => $this->getKey()])->toArray();
     }
 }

--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -35,6 +35,6 @@ class $CLASS$ extends Model
     $MORPH_TO$
     public function toSearchableArray(): array
     {
-        return $this->only($this->getFillable());
+        return collect($this->only($this->getFillable()))->merge(['id' => $this->getKey()])->toArray();
     }
 }

--- a/src/Commands/stubs/model.users.stub
+++ b/src/Commands/stubs/model.users.stub
@@ -34,6 +34,6 @@ class $CLASS$ extends \App\Models\User
     $MORPH_TO$
     public function toSearchableArray(): array
     {
-        return $this->only($this->getFillable());
+        return collect($this->only($this->getFillable()))->merge(['id' => $this->getKey()])->toArray();
     }
 }


### PR DESCRIPTION
Fix: Added `id` to scout's toSearchableArray() for model generation